### PR TITLE
install dependant requirements when package is installed

### DIFF
--- a/wagon_tools/data/skeleton/setup.py
+++ b/wagon_tools/data/skeleton/setup.py
@@ -9,6 +9,7 @@ setup(name='proj',
       version="1.0",
       description="Project Description",
       packages=find_packages(),
+      install_requires=requirements,
       test_suite = 'tests',
       # include_package_data: to install data from MANIFEST.in
       include_package_data=True,


### PR DESCRIPTION
corrected setup.py so that all dependant packages (pandas, etc) get installed when the package is installed

tested successfully with a new virtual env and everything seems to be 👌
