### PR TITLE
add \ to remove warning caused by escape

### DIFF
--- a/wagon_tools/data/skeleton/proj/lib.py
+++ b/wagon_tools/data/skeleton/proj/lib.py
@@ -17,7 +17,7 @@ def clean_data(data):
     cols = [x for x in data.columns if x.find('vote') >= 0]
     data.drop(cols, axis=1, inplace=True)
     # Remove special characteres from columns
-    data.loc[:, 'civility'] = data['civility'].replace('\.', '', regex=True)
+    data.loc[:, 'civility'] = data['civility'].replace('\\.', '', regex=True)
     # Calculate Age from day of birth
     actual_year = datetime.datetime.now().year
     data.loc[:, 'Year_Month'] = pd.to_datetime(data.birthdate)


### PR DESCRIPTION
This fixes the following warning message during `make test`:
```toolbox2/lib.py:20
  /home/barangerbenjamin/code/lectures/code_as_a_product/toolbox2/toolbox2/lib.py:20: DeprecationWarning: invalid escape sequence \.
    data.loc[:, 'civility'] = data['civility'].replace('\.', '', regex=True)```